### PR TITLE
GUAC-1511: Add low-level support for audio input to libguac.

### DIFF
--- a/src/libguac/guacamole/user-fntypes.h
+++ b/src/libguac/guacamole/user-fntypes.h
@@ -116,6 +116,29 @@ typedef int guac_user_mouse_handler(guac_user* user, int x, int y,
 typedef int guac_user_key_handler(guac_user* user, int keysym, int pressed);
 
 /**
+ * Handler for Guacamole audio streams received from a user. Each such audio
+ * stream begins when the user sends an "audio" instruction. To handle received
+ * data along this stream, implementations of this handler must assign blob and
+ * end handlers to the given stream object.
+ *
+ * @param user
+ *     The user that opened the audio stream.
+ *
+ * @param stream
+ *     The stream object allocated by libguac to represent the audio stream
+ *     opened by the user.
+ *
+ * @param mimetype
+ *     The mimetype of the data that will be sent along the stream.
+ *
+ * @return
+ *     Zero if the opening of the audio stream has been handled successfully,
+ *     or non-zero if an error occurs.
+ */
+typedef int guac_user_audio_handler(guac_user* user, guac_stream* stream,
+        char* mimetype);
+
+/**
  * Handler for Guacamole clipboard streams received from a user. Each such
  * clipboard stream begins when the user sends a "clipboard" instruction. To
  * handle received data along this stream, implementations of this handler

--- a/src/libguac/guacamole/user.h
+++ b/src/libguac/guacamole/user.h
@@ -453,6 +453,28 @@ struct guac_user {
      */
     guac_user_put_handler* put_handler;
 
+    /**
+     * Handler for audio events sent by the Guacamole web-client. This handler
+     * will be called whenever the web-client wishes to send a continuous
+     * stream of audio data from some arbitrary source (a microphone, for
+     * example).
+     *
+     * The handler takes a guac_stream, which contains the stream index and
+     * will persist through the duration of the transfer, and the mimetype
+     * of the data being transferred.
+     *
+     * Example:
+     * @code
+     *     int audio_handler(guac_user* user, guac_stream* stream,
+     *             char* mimetype);
+     *
+     *     int guac_user_init(guac_user* user, int argc, char** argv) {
+     *         user->audio_handler = audio_handler;
+     *     }
+     * @endcode
+     */
+    guac_user_audio_handler* audio_handler;
+
 };
 
 /**

--- a/src/libguac/user-handlers.c
+++ b/src/libguac/user-handlers.c
@@ -47,6 +47,7 @@ __guac_instruction_handler_mapping __guac_instruction_handler_map[] = {
    {"end",        __guac_handle_end},
    {"get",        __guac_handle_get},
    {"put",        __guac_handle_put},
+   {"audio",      __guac_handle_audio},
    {NULL,         NULL}
 };
 
@@ -264,6 +265,29 @@ static guac_stream* __init_input_stream(guac_user* user, int stream_index) {
     stream->end_handler = NULL;
 
     return stream;
+
+}
+
+int __guac_handle_audio(guac_user* user, int argc, char** argv) {
+
+    /* Pull corresponding stream */
+    int stream_index = atoi(argv[0]);
+    guac_stream* stream = __init_input_stream(user, stream_index);
+    if (stream == NULL)
+        return 0;
+
+    /* If supported, call handler */
+    if (user->audio_handler)
+        return user->audio_handler(
+            user,
+            stream,
+            argv[1] /* mimetype */
+        );
+
+    /* Otherwise, abort */
+    guac_protocol_send_ack(user->socket, stream,
+            "Audio input unsupported", GUAC_PROTOCOL_STATUS_UNSUPPORTED);
+    return 0;
 
 }
 

--- a/src/libguac/user-handlers.h
+++ b/src/libguac/user-handlers.h
@@ -93,6 +93,13 @@ __guac_instruction_handler __guac_handle_mouse;
 __guac_instruction_handler __guac_handle_key;
 
 /**
+ * Internal initial handler for the audio instruction. When a audio
+ * instruction is received, this handler will be called. The client's audio
+ * handler will be invoked if defined.
+ */
+__guac_instruction_handler __guac_handle_audio;
+
+/**
  * Internal initial handler for the clipboard instruction. When a clipboard
  * instruction is received, this handler will be called. The client's clipboard
  * handler will be invoked if defined.


### PR DESCRIPTION
This change adds support for the "audio" instruction when received from a connected user. Prior to this, audio streams were only provided in the outbound direction, with inbound handling of the "audio" instruction restricted to the JavaScript `Guacamole.Client` class.