### PR TITLE
GUAC-1517: Only allocate filesystem objects once per Guacamole connection.

### DIFF
--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -82,6 +82,10 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     client->join_handler = guac_rdp_user_join_handler;
     client->free_handler = guac_rdp_client_free_handler;
 
+#ifdef ENABLE_COMMON_SSH
+    guac_common_ssh_init(client);
+#endif
+
     return 0;
 
 }
@@ -99,6 +103,26 @@ int guac_rdp_client_free_handler(guac_client* client) {
 
     /* Free display update module */
     guac_rdp_disp_free(rdp_client->disp);
+
+    /* Clean up filesystem, if allocated */
+    if (rdp_client->filesystem != NULL)
+        guac_rdp_fs_free(rdp_client->filesystem);
+
+#ifdef ENABLE_COMMON_SSH
+    /* Free SFTP filesystem, if loaded */
+    if (rdp_client->sftp_filesystem)
+        guac_common_ssh_destroy_sftp_filesystem(rdp_client->sftp_filesystem);
+
+    /* Free SFTP session */
+    if (rdp_client->sftp_session)
+        guac_common_ssh_destroy_session(rdp_client->sftp_session);
+
+    /* Free SFTP user */
+    if (rdp_client->sftp_user)
+        guac_common_ssh_destroy_user(rdp_client->sftp_user);
+
+    guac_common_ssh_uninit();
+#endif
 
     /* Free client data */
     guac_common_clipboard_free(rdp_client->clipboard);

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.c
@@ -152,8 +152,5 @@ void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr) {
     /* Init data */
     device->data = rdp_client->filesystem;
 
-    /* Announce filesystem to owner */
-    guac_client_for_owner(client, guac_rdp_fs_expose, rdp_client->filesystem);
-
 }
 


### PR DESCRIPTION
From [GUAC-1517](https://glyptodon.org/jira/browse/GUAC-1517):

> After the RDP session is disconnected and reconnected, the filesystem object for the RDPDR drive, SFTP, etc. is recreated, but the original object is never freed and undefined. The client thus has an ever-increasing stack of filesystems in the Guacamole menu, only the most recent of which will actually be functional.

This change allocates the SFTP and RDP-specific filesystems only once per Guacamole connection, even if RDP reconnects. As neither of these filesystem implementations actually use the RDP client/connection (they are only used *by* the RDP client), this is OK.