### PR TITLE
GUACAMOLE-33: Fix duplication of mouse cursors

### DIFF
--- a/src/common/guac_cursor.c
+++ b/src/common/guac_cursor.c
@@ -367,3 +367,12 @@ void guac_common_cursor_set_blank(guac_common_cursor* cursor) {
 
 }
 
+void guac_common_cursor_remove_user(guac_common_cursor* cursor,
+        guac_user* user) {
+
+    /* Disassociate from given user */
+    if (cursor->user == user)
+        cursor->user = NULL;
+
+}
+

--- a/src/common/guac_cursor.h
+++ b/src/common/guac_cursor.h
@@ -249,4 +249,19 @@ void guac_common_cursor_set_ibar(guac_common_cursor* cursor);
  */
 void guac_common_cursor_set_blank(guac_common_cursor* cursor);
 
+/**
+ * Removes the given user, such that future synchronization will not occur.
+ * This is necessary when a user leaves the connection. If a user leaves the
+ * connection and this is not called, the corresponding guac_user and socket
+ * may cease to be valid, and future synchronization attempts will segfault.
+ *
+ * @param cursor
+ *     The cursor to remove the user from.
+ *
+ * @param user
+ *     The user to remove.
+ */
+void guac_common_cursor_remove_user(guac_common_cursor* cursor,
+        guac_user* user);
+
 #endif

--- a/src/common/guac_cursor.h
+++ b/src/common/guac_cursor.h
@@ -252,8 +252,8 @@ void guac_common_cursor_set_blank(guac_common_cursor* cursor);
 /**
  * Removes the given user, such that future synchronization will not occur.
  * This is necessary when a user leaves the connection. If a user leaves the
- * connection and this is not called, the corresponding guac_user and socket
- * may cease to be valid, and future synchronization attempts will segfault.
+ * connection and this is not called, the mouse cursor state may not update
+ * correctly in response to mouse events.
  *
  * @param cursor
  *     The cursor to remove the user from.

--- a/src/protocols/rdp/user.c
+++ b/src/protocols/rdp/user.c
@@ -122,3 +122,12 @@ int guac_rdp_user_file_handler(guac_user* user, guac_stream* stream,
     return 0;
 }
 
+int guac_rdp_user_leave_handler(guac_user* user) {
+
+    guac_rdp_client* rdp_client = (guac_rdp_client*) user->client->data;
+
+    guac_common_cursor_remove_user(rdp_client->display->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/rdp/user.h
+++ b/src/protocols/rdp/user.h
@@ -28,6 +28,11 @@
 guac_user_join_handler guac_rdp_user_join_handler;
 
 /**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_rdp_user_leave_handler;
+
+/**
  * Handler for received simple file uploads. This handler will automatically
  * select between RDPDR and SFTP depending on which is available and which has
  * priority given associated settings.

--- a/src/protocols/ssh/user.c
+++ b/src/protocols/ssh/user.c
@@ -82,3 +82,12 @@ int guac_ssh_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
+int guac_ssh_user_leave_handler(guac_user* user) {
+
+    guac_ssh_client* ssh_client = (guac_ssh_client*) user->client->data;
+
+    guac_common_cursor_remove_user(ssh_client->term->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/ssh/user.h
+++ b/src/protocols/ssh/user.h
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#ifndef GUAC_VNC_USER_H
-#define GUAC_VNC_USER_H
+#ifndef GUAC_SSH_USER_H
+#define GUAC_SSH_USER_H
 
 #include "config.h"
 
@@ -28,6 +28,11 @@
  * Handler for joining users.
  */
 guac_user_join_handler guac_ssh_user_join_handler;
+
+/**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_ssh_user_leave_handler;
 
 #endif
 

--- a/src/protocols/telnet/user.c
+++ b/src/protocols/telnet/user.c
@@ -78,3 +78,13 @@ int guac_telnet_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
+int guac_telnet_user_leave_handler(guac_user* user) {
+
+    guac_telnet_client* telnet_client =
+        (guac_telnet_client*) user->client->data;
+
+    guac_common_cursor_remove_user(telnet_client->term->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/telnet/user.h
+++ b/src/protocols/telnet/user.h
@@ -29,5 +29,10 @@
  */
 guac_user_join_handler guac_telnet_user_join_handler;
 
+/**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_telnet_user_leave_handler;
+
 #endif
 

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -52,6 +52,7 @@ int guac_client_init(guac_client* client) {
 
     /* Set handlers */
     client->join_handler = guac_vnc_user_join_handler;
+    client->leave_handler = guac_vnc_user_leave_handler;
     client->free_handler = guac_vnc_client_free_handler;
 
     return 0;

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -97,3 +97,12 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
+int guac_vnc_user_leave_handler(guac_user* user) {
+
+    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
+
+    guac_common_cursor_remove_user(vnc_client->display->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/vnc/user.h
+++ b/src/protocols/vnc/user.h
@@ -29,5 +29,10 @@
  */
 guac_user_join_handler guac_vnc_user_join_handler;
 
+/**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_vnc_user_leave_handler;
+
 #endif
 


### PR DESCRIPTION
From [GUACAMOLE-33](https://issues.apache.org/jira/browse/GUACAMOLE-33):

> This is caused by the lack of a mechanism to signal `guac_common_cursor` of a leaving user. Such a mechanism used to exist, but was removed when thought unnecessary.
> 
> It turns out this is actually necessary, as there is otherwise no guarantee that a newly-allocated user will have a different memory address from the user that just left, and thus certain cursor updates (such as the setting of opacity) may be omitted under the assumption that the user must be the same. *This assumption can fail frequently*, as the memory manager will often service a memory allocation request using a recently-freed memory block.