### PR TITLE
GUACAMOLE-34: Ensure client is cleaned up whenever the client thread terminates.

### DIFF
--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -178,8 +178,11 @@ void* ssh_client_thread(void* data) {
     pthread_t input_thread;
 
     /* Init SSH base libraries */
-    if (guac_common_ssh_init(client))
+    if (guac_common_ssh_init(client)) {
+        guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                "SSH library initialization failed");
         return NULL;
+    }
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {


### PR DESCRIPTION
From [GUACAMOLE-34](https://issues.apache.org/jira/browse/GUACAMOLE-34):

> This is caused by the lack of `guac_client_abort()` or `guac_client_stop()` call in some cases where the client thread otherwise terminates. The connection will full close under ONLY the following circumstances:
> 
> 1. All users disconnect (close their browser tabs, manually select "Disconnect" within the guac menu, etc.)
> 2. `guac_client_stop()` is called
> 3. `guac_client_abort()` is called
> 
> If the internal client disconnects and terminates its own thread, it should also invoke `guac_client_stop()` or `guac_client_abort()` to ensure connected users are forced off. Otherwise, users will be confused why their connection remains active with an unresponsive remote desktop session.
