### PR TITLE
GUACAMOLE-25: Avoid unnecessary allocation of temporary string for guac_rdp_ptr_to_string().

### DIFF
--- a/src/protocols/rdp/audio_input.c
+++ b/src/protocols/rdp/audio_input.c
@@ -185,9 +185,11 @@ int guac_rdp_audio_end_handler(guac_user* user, guac_stream* stream) {
 void guac_rdp_audio_load_plugin(rdpContext* context, guac_rdp_dvc_list* list) {
 
     guac_client* client = ((rdp_freerdp_context*) context)->client;
+    char client_ref[GUAC_RDP_PTR_STRING_LENGTH];
 
     /* Add "AUDIO_INPUT" channel */
-    guac_rdp_dvc_list_add(list, "guacai", guac_rdp_ptr_to_string(client), NULL);
+    guac_rdp_ptr_to_string(client, client_ref);
+    guac_rdp_dvc_list_add(list, "guacai", client_ref, NULL);
 
 }
 

--- a/src/protocols/rdp/ptr_string.c
+++ b/src/protocols/rdp/ptr_string.c
@@ -25,20 +25,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/**
- * The maximum number of bytes required to represent a pointer printed using
- * printf()'s "%p". This will be the size of the hex prefix ("0x"), null
- * terminator, plus two bytes for every byte required by a pointer.
- */
-#define GUAC_RDP_PTR_STRING_LENGTH (sizeof("0x") + (sizeof(void*) * 2))
-
-char* guac_rdp_ptr_to_string(void* data) {
+void guac_rdp_ptr_to_string(void* data, char* str) {
 
     /* Convert pointer to string */
-    char* str = malloc(GUAC_RDP_PTR_STRING_LENGTH);
     sprintf(str, "%p", data);
-
-    return str;
 
 }
 

--- a/src/protocols/rdp/ptr_string.h
+++ b/src/protocols/rdp/ptr_string.h
@@ -25,6 +25,13 @@
 #include <guacamole/client.h>
 
 /**
+ * The maximum number of bytes required to represent a pointer printed using
+ * printf()'s "%p". This will be the size of the hex prefix ("0x"), null
+ * terminator, plus two bytes for every byte required by a pointer.
+ */
+#define GUAC_RDP_PTR_STRING_LENGTH (sizeof("0x") + (sizeof(void*) * 2))
+
+/**
  * Converts the given string back into a void pointer. The string MUST have
  * been produced via guac_rdp_ptr_to_string().
  *
@@ -40,18 +47,17 @@ void* guac_rdp_string_to_ptr(const char* str);
 /**
  * Converts a void pointer into a string representation, safe for use with
  * parts of the FreeRDP API which provide only for passing arbitrary strings,
- * despite being within the same memory area. The returned string must
- * eventually be freed with a call to free().
+ * despite being within the same memory area.
  *
  * @param data
  *     The void pointer to convert to a string.
  *
- * @return
- *     A newly-allocated string containing the string representation of the
- *     given void pointer. This string must eventually be freed with a call to
- *     free().
+ * @param str
+ *     The buffer in which the string representation of the given void pointer
+ *     should be stored. This buffer must have at least
+ *     GUAC_RDP_PTR_STRING_LENGTH bytes available.
  */
-char* guac_rdp_ptr_to_string(void* data);
+void guac_rdp_ptr_to_string(void* data, char* str);
 
 #endif
 


### PR DESCRIPTION
The current code leaks the storage for the stringified pointer allocated by `guac_rdp_ptr_to_string()`, but it's really not necessary allocate the string at all. Better that `guac_rdp_ptr_to_string()` be provided a sufficiently-large buffer.