### PR TITLE
GUACAMOLE-51: Separate RDP keyboard handling into dedicated files / structures.

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -28,6 +28,7 @@ libguac_client_rdp_la_SOURCES = \
     client.c                    \
     dvc.c                       \
     input.c                     \
+    keyboard.c                  \
     ptr_string.c                \
     rdp.c                       \
     rdp_bitmap.c                \
@@ -94,6 +95,7 @@ noinst_HEADERS =                             \
     client.h                                 \
     dvc.h                                    \
     input.h                                  \
+    keyboard.h                               \
     ptr_string.h                             \
     rdp.h                                    \
     rdp_bitmap.h                             \

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -23,7 +23,6 @@
 #include "client.h"
 #include "rdp.h"
 #include "rdp_disp.h"
-#include "rdp_keymap.h"
 #include "user.h"
 
 #ifdef ENABLE_COMMON_SSH
@@ -75,10 +74,6 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
 
     /* Init RDP lock */
     pthread_mutex_init(&(rdp_client->rdp_lock), &(rdp_client->attributes));
-
-    /* Clear keysym state mapping and keymap */
-    memset(rdp_client->keysym_state, 0, sizeof(guac_rdp_keysym_state_map));
-    memset(rdp_client->keymap, 0, sizeof(guac_rdp_static_keymap));
 
     /* Set handlers */
     client->join_handler = guac_rdp_user_join_handler;

--- a/src/protocols/rdp/input.h
+++ b/src/protocols/rdp/input.h
@@ -20,50 +20,7 @@
 #ifndef GUAC_RDP_INPUT_H
 #define GUAC_RDP_INPUT_H
 
-#include <guacamole/client.h>
 #include <guacamole/user.h>
-
-/**
- * Presses or releases the given keysym, sending an appropriate set of key
- * events to the RDP server. The key events sent will depend on the current
- * keymap.
- *
- * @param client
- *     The guac_client associated with the current RDP session.
- *
- * @param keysym
- *     The keysym being pressed or released.
- *
- * @param pressed
- *     Zero if the keysym is being released, non-zero otherwise.
- *
- * @return
- *     Zero if the keys were successfully sent, non-zero otherwise.
- */
-int guac_rdp_send_keysym(guac_client* client, int keysym, int pressed);
-
-/**
- * For every keysym in the given NULL-terminated array of keysyms, update
- * the current state of that key conditionally. For each key in the "from"
- * state (0 being released and 1 being pressed), that key will be updated
- * to the "to" state.
- *
- * @param client
- *     The guac_client associated with the current RDP session.
- *
- * @param keysym_string
- *     A NULL-terminated array of keysyms, each of which will be updated.
- *
- * @param from
- *     0 if the state of currently-released keys should be updated, or 1 if
- *     the state of currently-pressed keys should be updated.
- *
- * @param to 
- *     0 if the keys being updated should be marked as released, or 1 if
- *     the keys being updated should be marked as pressed.
- */
-void guac_rdp_update_keysyms(guac_client* client, const int* keysym_string,
-        int from, int to);
 
 /**
  * Handler for Guacamole user mouse events.

--- a/src/protocols/rdp/keyboard.c
+++ b/src/protocols/rdp/keyboard.c
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+
+#include "client.h"
+#include "keyboard.h"
+#include "rdp.h"
+#include "rdp_keymap.h"
+
+#include <freerdp/freerdp.h>
+#include <freerdp/input.h>
+#include <guacamole/client.h>
+
+#include <pthread.h>
+#include <stdlib.h>
+
+/**
+ * Loads all keysym/scancode mappings declared within the given keymap and its
+ * parent keymap, if any. These mappings are stored within the given
+ * guac_rdp_keyboard structure for future use in translating keysyms to the
+ * scancodes required by RDP key events.
+ *
+ * @param keyboard
+ *     The guac_rdp_keyboard which should be initialized with the
+ *     keysym/scancode mapping defined in the given keymap.
+ *
+ * @param keymap
+ *     The keymap to use to populate the given client's keysym/scancode
+ *     mapping.
+ */
+static void __guac_rdp_keyboard_load_keymap(guac_rdp_keyboard* keyboard,
+        const guac_rdp_keymap* keymap) {
+
+    /* Get mapping */
+    const guac_rdp_keysym_desc* mapping = keymap->mapping;
+
+    /* If parent exists, load parent first */
+    if (keymap->parent != NULL)
+        __guac_rdp_keyboard_load_keymap(keyboard, keymap->parent);
+
+    /* Log load */
+    guac_client_log(keyboard->client, GUAC_LOG_INFO,
+            "Loading keymap \"%s\"", keymap->name);
+
+    /* Load mapping into keymap */
+    while (mapping->keysym != 0) {
+
+        /* Copy mapping */
+        GUAC_RDP_KEYSYM_LOOKUP(keyboard->keymap, mapping->keysym) = *mapping;
+
+        /* Next keysym */
+        mapping++;
+
+    }
+
+}
+
+guac_rdp_keyboard* guac_rdp_keyboard_alloc(guac_client* client,
+        const guac_rdp_keymap* keymap) {
+
+    guac_rdp_keyboard* keyboard = calloc(1, sizeof(guac_rdp_keyboard));
+    keyboard->client = client;
+
+    /* Load keymap into keyboard */
+    __guac_rdp_keyboard_load_keymap(keyboard, keymap);
+
+    return keyboard;
+
+}
+
+void guac_rdp_keyboard_free(guac_rdp_keyboard* keyboard) {
+    free(keyboard);
+}
+
+int guac_rdp_keyboard_send_event(guac_rdp_keyboard* keyboard,
+        int keysym, int pressed) {
+
+    guac_client* client = keyboard->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+
+    /* If keysym can be in lookup table */
+    if (GUAC_RDP_KEYSYM_STORABLE(keysym)) {
+
+        /* Look up scancode mapping */
+        const guac_rdp_keysym_desc* keysym_desc =
+            &GUAC_RDP_KEYSYM_LOOKUP(keyboard->keymap, keysym);
+
+        /* If defined, send event */
+        if (keysym_desc->scancode != 0) {
+
+            pthread_mutex_lock(&(rdp_client->rdp_lock));
+
+            /* If defined, send any prerequesite keys that must be set */
+            if (keysym_desc->set_keysyms != NULL)
+                guac_rdp_keyboard_send_events(keyboard,
+                        keysym_desc->set_keysyms, 0, 1);
+
+            /* If defined, release any keys that must be cleared */
+            if (keysym_desc->clear_keysyms != NULL)
+                guac_rdp_keyboard_send_events(keyboard,
+                        keysym_desc->clear_keysyms, 1, 0);
+
+            /* Determine proper event flag for pressed state */
+            int pressed_flags;
+            if (pressed)
+                pressed_flags = KBD_FLAGS_DOWN;
+            else
+                pressed_flags = KBD_FLAGS_RELEASE;
+
+            /* Skip if not yet connected */
+            freerdp* rdp_inst = rdp_client->rdp_inst;
+            if (rdp_inst == NULL) {
+                pthread_mutex_unlock(&(rdp_client->rdp_lock));
+                return 0;
+            }
+
+            /* Send actual key */
+            rdp_inst->input->KeyboardEvent(rdp_inst->input,
+                    keysym_desc->flags | pressed_flags,
+                    keysym_desc->scancode);
+
+            /* If defined, release any keys that were originally released */
+            if (keysym_desc->set_keysyms != NULL)
+                guac_rdp_keyboard_send_events(keyboard,
+                        keysym_desc->set_keysyms, 0, 0);
+
+            /* If defined, send any keys that were originally set */
+            if (keysym_desc->clear_keysyms != NULL)
+                guac_rdp_keyboard_send_events(keyboard,
+                        keysym_desc->clear_keysyms, 1, 1);
+
+            pthread_mutex_unlock(&(rdp_client->rdp_lock));
+
+            return 0;
+
+        }
+    }
+
+    /* Fall back to unicode events if undefined inside current keymap */
+
+    /* Only send when key pressed - Unicode events do not have
+     * DOWN/RELEASE flags */
+    if (pressed) {
+
+        guac_client_log(client, GUAC_LOG_DEBUG,
+                "Sending keysym 0x%x as Unicode", keysym);
+
+        /* Translate keysym into codepoint */
+        int codepoint;
+        if (keysym <= 0xFF)
+            codepoint = keysym;
+        else if (keysym >= 0x1000000)
+            codepoint = keysym & 0xFFFFFF;
+        else {
+            guac_client_log(client, GUAC_LOG_DEBUG,
+                    "Unmapped keysym has no equivalent unicode "
+                    "value: 0x%x", keysym);
+            return 0;
+        }
+
+        pthread_mutex_lock(&(rdp_client->rdp_lock));
+
+        /* Skip if not yet connected */
+        freerdp* rdp_inst = rdp_client->rdp_inst;
+        if (rdp_inst == NULL) {
+            pthread_mutex_unlock(&(rdp_client->rdp_lock));
+            return 0;
+        }
+
+        /* Send Unicode event */
+        rdp_inst->input->UnicodeKeyboardEvent(
+                rdp_inst->input,
+                0, codepoint);
+
+        pthread_mutex_unlock(&(rdp_client->rdp_lock));
+
+    }
+    
+    return 0;
+}
+
+void guac_rdp_keyboard_send_events(guac_rdp_keyboard* keyboard,
+        const int* keysym_string, int from, int to) {
+
+    int keysym;
+
+    /* Send all keysyms in string, NULL terminated */
+    while ((keysym = *keysym_string) != 0) {
+
+        /* Get current keysym state */
+        int current_state =
+            GUAC_RDP_KEYSYM_LOOKUP(keyboard->keysym_state, keysym);
+
+        /* If key is currently in given state, send event for changing it to
+         * specified "to" state */
+        if (current_state == from)
+            guac_rdp_keyboard_send_event(keyboard, *keysym_string, to);
+
+        /* Next keysym */
+        keysym_string++;
+
+    }
+
+}
+
+int guac_rdp_keyboard_update_keysym(guac_rdp_keyboard* keyboard,
+        int keysym, int pressed) {
+
+    /* Update keysym state */
+    if (GUAC_RDP_KEYSYM_STORABLE(keysym))
+        GUAC_RDP_KEYSYM_LOOKUP(keyboard->keysym_state, keysym) = pressed;
+
+    return guac_rdp_keyboard_send_event(keyboard, keysym, pressed);
+
+}
+

--- a/src/protocols/rdp/keyboard.h
+++ b/src/protocols/rdp/keyboard.h
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_RDP_KEYBOARD_H
+#define GUAC_RDP_KEYBOARD_H
+
+#include "rdp_keymap.h"
+
+#include <guacamole/client.h>
+
+/**
+ * The current keyboard state of an RDP session.
+ */
+typedef struct guac_rdp_keyboard {
+
+    /**
+     * The guac_client associated with the RDP session whose keyboard state is
+     * being managed by this guac_rdp_keyboard.
+     */
+    guac_client* client;
+
+    /**
+     * The keymap to use when translating keysyms into scancodes or sequences
+     * of scancodes for RDP.
+     */
+    guac_rdp_static_keymap keymap;
+
+    /**
+     * The local state of all keys, based on whether Guacamole key events for
+     * pressing/releasing particular keysyms have been received. This is used
+     * together with the associated keymap to determine the sequence of RDP key
+     * events sent to duplicate the effect of a particular keysym.
+     */
+    guac_rdp_keysym_state_map keysym_state;
+
+} guac_rdp_keyboard;
+
+/**
+ * Allocates a new guac_rdp_keyboard which manages the keyboard state of the
+ * RDP session associated with the given guac_client. Keyboard events will be
+ * dynamically translated from keysym to RDP scancode according to the provided
+ * keymap. The returned guac_rdp_keyboard must eventually be freed with
+ * guac_rdp_keyboard_free().
+ *
+ * @param client
+ *     The guac_client associated with the RDP session whose keyboard state is
+ *     to be managed by the newly-allocated guac_rdp_keyboard.
+ *
+ * @param keymap
+ *     The keymap which should be used to translate keyboard events.
+ *
+ * @return
+ *     A newly-allocated guac_rdp_keyboard which manages the keyboard state
+ *     for the RDP session associated given guac_client.
+ */
+guac_rdp_keyboard* guac_rdp_keyboard_alloc(guac_client* client,
+        const guac_rdp_keymap* keymap);
+
+/**
+ * Frees all memory allocated for the given guac_rdp_keyboard. The
+ * guac_rdp_keyboard must have been previously allocated via
+ * guac_rdp_keyboard_alloc().
+ *
+ * @param keyboard
+ *     The guac_rdp_keyboard instance which should be freed.
+ */
+void guac_rdp_keyboard_free(guac_rdp_keyboard* keyboard);
+
+/**
+ * Sends one or more RDP key events, effectively pressing or releasing the
+ * given keysym on the remote side. The key events sent will depend on the
+ * current keymap. The locally-stored state of each key is remains untouched.
+ *
+ * @param keyboard
+ *     The guac_rdp_keyboard associated with the current RDP session.
+ *
+ * @param keysym
+ *     The keysym being pressed or released.
+ *
+ * @param pressed
+ *     Zero if the keysym is being released, non-zero otherwise.
+ *
+ * @return
+ *     Zero if the keys were successfully sent, non-zero otherwise.
+ */
+int guac_rdp_keyboard_send_event(guac_rdp_keyboard* keyboard,
+        int keysym, int pressed);
+
+/**
+ * For every keysym in the given NULL-terminated array of keysyms, send the RDP
+ * key events required to update the remote state of those keys as specified,
+ * depending on the current local state of those keysyms.  For each key in the
+ * "from" state (0 being released and 1 being pressed), that key will be
+ * updated to the "to" state. The locally-stored state of each key is remains
+ * untouched.
+ *
+ * @param keyboard
+ *     The guac_rdp_keyboard associated with the current RDP session.
+ *
+ * @param keysym_string
+ *     A NULL-terminated array of keysyms, each of which will be updated.
+ *
+ * @param from
+ *     0 if the state of currently-released keys should be updated, or 1 if
+ *     the state of currently-pressed keys should be updated.
+ *
+ * @param to 
+ *     0 if the keys being updated should be marked as released, or 1 if
+ *     the keys being updated should be marked as pressed.
+ */
+void guac_rdp_keyboard_send_events(guac_rdp_keyboard* keyboard,
+        const int* keysym_string, int from, int to);
+
+/**
+ * Updates the local state of the given keysym, sending the key events required
+ * to replicate that state remotely (on the RDP server). The key events sent
+ * will depend on the current keymap.
+ *
+ * @param keyboard
+ *     The guac_rdp_keyboard associated with the current RDP session.
+ *
+ * @param keysym
+ *     The keysym being pressed or released.
+ *
+ * @param pressed
+ *     Zero if the keysym is being released, non-zero otherwise.
+ *
+ * @return
+ *     Zero if the keys were successfully sent, non-zero otherwise.
+ */
+int guac_rdp_keyboard_update_keysym(guac_rdp_keyboard* keyboard,
+        int keysym, int pressed);
+
+#endif
+

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -27,9 +27,9 @@
 #include "guac_display.h"
 #include "guac_surface.h"
 #include "guac_list.h"
+#include "keyboard.h"
 #include "rdp_disp.h"
 #include "rdp_fs.h"
-#include "rdp_keymap.h"
 #include "rdp_settings.h"
 
 #include <freerdp/freerdp.h>
@@ -88,20 +88,9 @@ typedef struct guac_rdp_client {
     guac_common_surface* current_surface;
 
     /**
-     * The keymap to use when translating keysyms into scancodes or sequences
-     * of scancodes for RDP.
+     * The current state of the keyboard with respect to the RDP session.
      */
-    guac_rdp_static_keymap keymap;
-
-    /**
-     * The state of all keys, based on whether events for pressing/releasing
-     * particular keysyms have been received. This is necessary in order to
-     * determine which keys must be released/pressed when a particular
-     * keysym can only be typed through a sequence of scancodes (such as
-     * an Alt-code) because the server-side keymap does not support that
-     * keysym.
-     */
-    guac_rdp_keysym_state_map keysym_state;
+    guac_rdp_keyboard* keyboard;
 
     /**
      * The current clipboard contents.


### PR DESCRIPTION
Finishing the RDP portion of [GUACAMOLE-51](https://issues.apache.org/jira/browse/GUACAMOLE-51) is getting a bit hairy since the keymap structures are interwoven with the rest of the RDP client code. Really shouldn't have done it that way.

This change moves the main keymap-driven keyboard translation code into its own files and structures, centered around the `guac_rdp_keyboard` abstraction.