### PR TITLE
GUACAMOLE-87: Bump guacamole-server version numbers to 0.9.10-incubating.

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -105,7 +105,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 0.9.9, Guacamole terminal session control utility.
+guacctl 0.9.10-incubating, Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [0.9.9])
+AC_INIT([guacamole-server], [0.9.10-incubating])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -4,7 +4,7 @@
 #
 
 PROJECT_NAME   = libguac
-PROJECT_NUMBER = 0.9.9
+PROJECT_NUMBER = 0.9.10-incubating
 
 #
 # Warn about undocumented parameters and return values, but do not fill output

--- a/src/guacd/man/guacd.8
+++ b/src/guacd/man/guacd.8
@@ -1,4 +1,4 @@
-.TH guacd 8 "15 Dec 2015" "version 0.9.9" "Guacamole"
+.TH guacd 8 "25 Aug 2016" "version 0.9.10-incubating" "Guacamole"
 .
 .SH NAME
 guacd \- Guacamole proxy daemon

--- a/src/guacd/man/guacd.conf.5
+++ b/src/guacd/man/guacd.conf.5
@@ -1,4 +1,4 @@
-.TH guacd.conf 5 "15 Dec 2015" "version 0.9.9" "Guacamole"
+.TH guacd.conf 5 "25 Aug 2016" "version 0.9.10-incubating" "Guacamole"
 .
 .SH NAME
 /etc/guacamole/guacd.conf \- Configuration file for guacd

--- a/src/guacenc/man/guacenc.1
+++ b/src/guacenc/man/guacenc.1
@@ -1,4 +1,4 @@
-.TH guacenc 1 "12 Mar 2016" "version 0.9.9" "Guacamole"
+.TH guacenc 1 "25 Aug 2016" "version 0.9.10-incubating" "Guacamole"
 .
 .SH NAME
 guacenc \- Guacamole video encoder

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -103,7 +103,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic -Iguacamole
 
 libguac_la_LDFLAGS =     \
-    -version-info 11:0:0 \
+    -version-info 12:0:0 \
     @CAIRO_LIBS@         \
     @JPEG_LIBS@          \
     @PNG_LIBS@           \


### PR DESCRIPTION
The Dockerfile is untouched because it needs more work before the release; simply bumping the version numbers in it would be insufficient.