### PR TITLE
GUACAMOLE-117: Do not stop connection when the intent is to reconnect.

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -850,10 +850,6 @@ static int guac_rdp_handle_connection(guac_client* client) {
 
     }
 
-    /* Kill client and finish connection */
-    guac_client_stop(client);
-    guac_client_log(client, GUAC_LOG_INFO, "Internal RDP client disconnected");
-
     pthread_mutex_lock(&(rdp_client->rdp_lock));
 
     /* Disconnect client and channels */
@@ -880,6 +876,10 @@ static int guac_rdp_handle_connection(guac_client* client) {
     guac_common_display_free(rdp_client->display);
 
     pthread_mutex_unlock(&(rdp_client->rdp_lock));
+
+    /* Client is now disconnected */
+    guac_client_log(client, GUAC_LOG_INFO, "Internal RDP client disconnected");
+
     return 0;
 
 }


### PR DESCRIPTION
From [GUACAMOLE-117](https://issues.apache.org/jira/browse/GUACAMOLE-114):

>
> Commit a64c3e0 from [GUACAMOLE-34](https://issues.apache.org/jira/browse/GUACAMOLE-34) added several calls to `guac_client_stop()`, one of which runs in all cases after the connection has closed, even if that closure is due to the need to handle a resize.
>
> `guac_client_stop()` should not be invoked in that case. It should only be invoked when the connection absolutely must terminate.
>