### PR TITLE
GUACAMOLE-118: Use poll() instead of select()

### DIFF
--- a/src/protocols/rdp/client.h
+++ b/src/protocols/rdp/client.h
@@ -38,12 +38,12 @@
 
 /**
  * The amount of time to wait for a new message from the RDP server when
- * beginning a new frame. This value must be kept reasonably small such that
- * a slow RDP server will not prevent external events from being handled (such
- * as the stop signal from guac_client_stop()), but large enough that the
- * message handling loop does not eat up CPU spinning.
+ * beginning a new frame, in milliseconds. This value must be kept reasonably
+ * small such that a slow RDP server will not prevent external events from
+ * being handled (such as the stop signal from guac_client_stop()), but large
+ * enough that the message handling loop does not eat up CPU spinning.
  */
-#define GUAC_RDP_FRAME_START_TIMEOUT 250000
+#define GUAC_RDP_FRAME_START_TIMEOUT 250
 
 /**
  * The native resolution of most RDP connections. As Windows and other systems
@@ -88,6 +88,12 @@
  * appropriately.
  */
 #define GUAC_RDP_AUDIO_BPS 16
+
+/**
+ * The maximum number of file descriptors which can be associated with an RDP
+ * connection.
+ */
+#define GUAC_RDP_MAX_FILE_DESCRIPTORS 32
 
 /**
  * Handler which frees all data associated with the guac_client.

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -29,10 +29,10 @@
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -442,17 +442,15 @@ void guac_telnet_send_user(telnet_t* telnet, const char* username) {
  */
 static int __guac_telnet_wait(int socket_fd) {
 
-    fd_set fds;
-    struct timeval timeout;
-
-    FD_ZERO(&fds);
-    FD_SET(socket_fd, &fds);
+    /* Build array of file descriptors */
+    struct pollfd fds[] = {{
+        .fd      = socket_fd,
+        .events  = POLLIN,
+        .revents = 0,
+    }};
 
     /* Wait for one second */
-    timeout.tv_sec = 1;
-    timeout.tv_usec = 0;
-
-    return select(socket_fd+1, &fds, NULL, NULL, &timeout);
+    return poll(fds, 1, 1000);
 
 }
 

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -32,12 +32,12 @@
 #include "typescript.h"
 
 #include <errno.h>
+#include <poll.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/select.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <wchar.h>
@@ -463,19 +463,15 @@ void guac_terminal_free(guac_terminal* term) {
  */
 static int guac_terminal_wait_for_data(int fd, int msec_timeout) {
 
-    /* Build fd_set */
-    fd_set fds;
-    FD_ZERO(&fds);
-    FD_SET(fd, &fds);
-
-    /* Split millisecond timeout into seconds and microseconds */
-    struct timeval timeout = {
-        .tv_sec  =  msec_timeout / 1000,
-        .tv_usec = (msec_timeout % 1000) * 1000
-    };
+    /* Build array of file descriptors */
+    struct pollfd fds[] = {{
+        .fd      = fd,
+        .events  = POLLIN,
+        .revents = 0,
+    }};
 
     /* Wait for data */
-    return select(fd+1, &fds, NULL, NULL, &timeout);
+    return poll(fds, 1, msec_timeout);
 
 }
 


### PR DESCRIPTION
In most cases, this was an extremely simple change. The change for RDP was slightly more complex, as an RDP connection may involve many file descriptors. The form of the change should nonetheless look familiar.

Beware that I had to reformat RDP's "wait for messages" function somewhat, such that the behavior of the function could be more easily verified.