### PR TITLE
GUACAMOLE-143: Add missing files to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,9 @@ SUBDIRS += src/guacenc
 endif
 
 EXTRA_DIST =     \
+    DISCLAIMER   \
     LICENSE      \
+    NOTICE       \
     bin/guacctl  \
     doc/Doxyfile
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,11 +70,14 @@ if ENABLE_GUACENC
 SUBDIRS += src/guacenc
 endif
 
-EXTRA_DIST =     \
-    CONTRIBUTING \
-    DISCLAIMER   \
-    LICENSE      \
-    NOTICE       \
-    bin/guacctl  \
-    doc/Doxyfile
+EXTRA_DIST =      \
+    .dockerignore \
+    CONTRIBUTING  \
+    DISCLAIMER    \
+    Dockerfile    \
+    LICENSE       \
+    NOTICE        \
+    bin/guacctl   \
+    doc/Doxyfile  \
+    src/guacd-docker
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ SUBDIRS += src/guacenc
 endif
 
 EXTRA_DIST =     \
+    CONTRIBUTING \
     DISCLAIMER   \
     LICENSE      \
     NOTICE       \


### PR DESCRIPTION
From @justinmclean regarding the [0.9.10-incubating (RC2) release vote](http://mail-archives.apache.org/mod_mbox/incubator-general/201612.mbox/%3CB6E93324-682C-4690-966B-EC0A4E39DDFE%40classsoftware.com%3E):

>
> Sorry but it’s -1 binding as the server artefact is missing a DISCLAIMER and NOTICE file.
>

These files are missing from the source .tar.gz because they are not specified within `EXTRA_DIST` of the top-level `.Makefile.am`. Also missing is `CONTRIBUTING`, along with everything Docker-related.
