### PR TITLE
GUACAMOLE-145: Update README to include (correct) required and optional dependencies.

### DIFF
--- a/README
+++ b/README
@@ -32,13 +32,68 @@ proxy which translates between arbitrary protocols and the Guacamole protocol.
 
 
 ------------------------------------------------------------
+ Required dependencies
+------------------------------------------------------------
+
+All software within guacamole-server is built using the popular GNU Automake,
+and thus provides the standard configure script. Before compiling, at least
+the following required dependencies must already be installed:
+
+    1) Cairo (http://cairographics.org/)
+
+    2) libjpeg-turbo (http://libjpeg-turbo.virtualgl.org/)
+       OR libjpeg (http://www.ijg.org/)
+
+    3) libpng (http://www.libpng.org/pub/png/libpng.html)
+
+    4) OSSP UUID (http://www.ossp.org/pkg/lib/uuid/)
+
+
+------------------------------------------------------------
+ Optional dependencies
+------------------------------------------------------------
+
+In addition, the following optional dependencies may be installed in order to
+enable optional features of Guacamole. Note that while the various supported
+protocols are technically optional, you will no doubt wish to install the 
+dependencies of at least ONE supported protocol, as Guacamole would be useless
+otherwise.
+
+    RDP:
+        * FreeRDP (http://www.freerdp.com/)
+
+    SSH:
+        * libssh2 (http://www.libssh2.org/)
+        * OpenSSL (https://www.openssl.org/)
+        * Pango (http://www.pango.org/)
+
+    Telnet:
+        * libtelnet (https://github.com/seanmiddleditch/libtelnet)
+        * Pango (http://www.pango.org/)
+
+    VNC:
+        * libVNCserver (http://libvnc.github.io/)
+
+    Support for audio within VNC:
+        * PulseAudio (http://www.freedesktop.org/wiki/Software/PulseAudio/)
+
+    Support for SFTP file transfer for VNC or RDP:
+        * libssh2 (http://www.libssh2.org/)
+        * OpenSSL (https://www.openssl.org/)
+
+    Support for WebP image compression:
+        * libwebp (https://developers.google.com/speed/webp/)
+
+    "guacenc" video encoding utility:
+        * FFmpeg (https://ffmpeg.org/)
+
+
+------------------------------------------------------------
  Compiling and installing guacd, libguac, etc.
 ------------------------------------------------------------
 
 All software within guacamole-server is built using the popular GNU Automake,
-and thus provides the standard configure script. Before compiling, you need to
-have compiled and installed libguac, the core Guacamole library. This is
-available from the main Apache Guacamole site at http://guacamole.incubator.apache.org/.
+and thus provides the standard configure script.
 
 1) Run configure
 


### PR DESCRIPTION
From @justinmclean regarding the [0.9.10-incubating (RC2) release vote](http://mail-archives.apache.org/mod_mbox/incubator-general/201612.mbox/%3CB6E93324-682C-4690-966B-EC0A4E39DDFE%40classsoftware.com%3E):

>
> When configuring the server I get this error:
> 
>     configure: error: "libpng is required for writing png messages"
> 
> But I do have libpng installed:
> 
>     brew install libpng
>     Warning: libpng-1.6.26 already installed
> 
> Is OSX a supported platform? It would be nice if the README had a bit more information on how to compile and what the dependancies are. For instance I think the instruction "Before compiling, you need to have compiled and installed libguac, the core Guacamole library” may possibly be misleading?
>

These changes update the `README` to more accurately represent the current build.