### PR TITLE
GUACAMOLE-172: Improve/fix processing lag calculations

### DIFF
--- a/src/libguac/user-handlers.c
+++ b/src/libguac/user-handlers.c
@@ -104,9 +104,8 @@ int __guac_handle_sync(guac_user* user, int argc, char** argv) {
     /* Update lag statistics if at least one frame has been rendered */
     if (user->last_frame_duration != 0) {
 
-        /* Approximate processing lag by summing the frame duration deltas */
-        int processing_lag = user->processing_lag + frame_duration
-                           - user->last_frame_duration;
+        /* Calculate lag using the previous frame as a baseline */
+        int processing_lag = frame_duration - user->last_frame_duration;
 
         /* Adjust back to zero if cumulative error leads to a negative value */
         if (processing_lag < 0)
@@ -116,8 +115,8 @@ int __guac_handle_sync(guac_user* user, int argc, char** argv) {
 
     }
 
-    /* Record duration of frame */
-    user->last_frame_duration = frame_duration;
+    /* Record baseline duration of frame by excluding lag */
+    user->last_frame_duration = frame_duration - user->processing_lag;
 
     if (user->sync_handler)
         return user->sync_handler(user, timestamp);

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -832,6 +832,13 @@ static int guac_rdp_handle_connection(guac_client* client) {
                     break;
 
             } while (wait_result > 0);
+
+            /* Record end of frame, excluding server-side rendering time (we
+             * assume server-side rendering time will be consistent between any
+             * two subsequent frames, and that this time should thus be
+             * excluded from the required wait period of the next frame). */
+            last_frame_end = frame_start;
+
         }
 
         /* If an error occurred, fail */
@@ -839,14 +846,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
             guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
                     "Connection closed.");
 
-        /* Record end of frame, excluding server-side rendering time (we assume
-         * server-side rendering time will be consistent between any two
-         * subsequent frames, and that this time should thus be excluded from
-         * the required wait period of the next frame). */
-        last_frame_end = guac_timestamp_current();
-
         /* Flush frame */
-        /* End of frame */
         guac_common_display_flush(rdp_client->display);
         guac_client_end_frame(client);
         guac_socket_flush(client->socket);

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -839,13 +839,17 @@ static int guac_rdp_handle_connection(guac_client* client) {
             guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
                     "Connection closed.");
 
+        /* Record end of frame, excluding server-side rendering time (we assume
+         * server-side rendering time will be consistent between any two
+         * subsequent frames, and that this time should thus be excluded from
+         * the required wait period of the next frame). */
+        last_frame_end = guac_timestamp_current();
+
+        /* Flush frame */
         /* End of frame */
         guac_common_display_flush(rdp_client->display);
         guac_client_end_frame(client);
         guac_socket_flush(client->socket);
-
-        /* Record end of frame */
-        last_frame_end = guac_timestamp_current();
 
     }
 

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -408,13 +408,16 @@ void* guac_vnc_client_thread(void* data) {
         if (wait_result < 0)
             guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR, "Connection closed.");
 
+        /* Record end of frame, excluding server-side rendering time (we assume
+         * server-side rendering time will be consistent between any two
+         * subsequent frames, and that this time should thus be excluded from
+         * the required wait period of the next frame). */
+        last_frame_end = guac_timestamp_current();
+
         /* Flush frame */
         guac_common_surface_flush(vnc_client->display->default_surface);
         guac_client_end_frame(client);
         guac_socket_flush(client->socket);
-
-        /* Record end of frame */
-        last_frame_end = guac_timestamp_current();
 
     }
 

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -402,17 +402,17 @@ void* guac_vnc_client_thread(void* data) {
 
             } while (wait_result > 0);
 
+            /* Record end of frame, excluding server-side rendering time (we
+             * assume server-side rendering time will be consistent between any
+             * two subsequent frames, and that this time should thus be
+             * excluded from the required wait period of the next frame). */
+            last_frame_end = frame_start;
+
         }
 
         /* If an error occurs, log it and fail */
         if (wait_result < 0)
             guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR, "Connection closed.");
-
-        /* Record end of frame, excluding server-side rendering time (we assume
-         * server-side rendering time will be consistent between any two
-         * subsequent frames, and that this time should thus be excluded from
-         * the required wait period of the next frame). */
-        last_frame_end = guac_timestamp_current();
 
         /* Flush frame */
         guac_common_surface_flush(vnc_client->display->default_surface);


### PR DESCRIPTION
This change modifies the lag calculations provided by libguac and used within the VNC and RDP protocols such that:

* Server processing time is excluded
* Bad client timestamps are ignored