### PR TITLE
GUACAMOLE-94: Use readdir() instead of readdir_r().

### DIFF
--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -595,16 +595,12 @@ const char* guac_rdp_fs_read_dir(guac_rdp_fs* fs, int file_id) {
             return NULL;
     }
 
-    /* Read next entry, stop if error */
-    if (readdir_r(file->dir, &(file->__dirent), &result))
-        return NULL;
-
-    /* If no more entries, return NULL */
-    if (result == NULL)
+    /* Read next entry, stop if error or no more entries */
+    if ((result = readdir(file->dir)) == NULL)
         return NULL;
 
     /* Return filename */
-    return file->__dirent.d_name;
+    return result->d_name;
 
 }
 

--- a/src/protocols/rdp/rdp_fs.h
+++ b/src/protocols/rdp/rdp_fs.h
@@ -217,12 +217,6 @@ typedef struct guac_rdp_fs_file {
     DIR* dir;
 
     /**
-     * The last read dirent structure. This is used if traversing the contents
-     * of a directory.
-     */
-    struct dirent __dirent;
-
-    /**
      * The pattern the check directory contents against, if any.
      */
     char dir_pattern[GUAC_RDP_FS_MAX_PATH];


### PR DESCRIPTION
glibc has taken it upon themselves to flag `readdir_r()` as deprecated in advance of any official change to POSIX. This breaks the guacamole-server build for any environment with a sufficiently-recent glibc.

It should be safe to use `readdir()` as multiple threads will not be accessing the same directory stream. From the glibc manpage for `readdir_r()`:

> In the current POSIX.1 specification (POSIX.1-2008), readdir(3) is not required to be thread-safe. However, in modern implementations (including the glibc implementation), concurrent calls to readdir(3) that specify different directory streams are thread-safe. Therefore, the use of readdir_r() is generally unnecessary in multithreaded programs.