### PR TITLE
GUACAMOLE-218: Reset internal RDPSND audio format counter whenever a new SNDC_FORMATS PDU is received.

### DIFF
--- a/src/protocols/rdp/guac_rdpsnd/rdpsnd_messages.c
+++ b/src/protocols/rdp/guac_rdpsnd/rdpsnd_messages.c
@@ -58,6 +58,9 @@ void guac_rdpsnd_formats_handler(guac_rdpsndPlugin* rdpsnd,
     /* Get audio stream from client data */
     guac_audio_stream* audio = rdp_client->audio;
 
+    /* Reset own format count */
+    rdpsnd->format_count = 0;
+
     /* Format header */
     Stream_Seek(input_stream, 14);
     Stream_Read_UINT16(input_stream, server_format_count);


### PR DESCRIPTION
If this is not done, the format count and indices will mismatch each time a new SNDC_FORMATS PDU is received from the RDP server, and further streaming of audio will fail. Older versions of Windows will only set the formats once, but Windows Server 2016 does this multiple times.