### PR TITLE
GUACAMOLE-217: Do not use FFmpeg's decoupled I/O functions if libavcodec older than 57.37.100.

### DIFF
--- a/src/guacenc/ffmpeg-compat.c
+++ b/src/guacenc/ffmpeg-compat.c
@@ -111,8 +111,8 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
     packet.data = NULL;
     packet.size = 0;
 
-/* For libavcodec < 57.16.0: input/output was not decoupled */
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,16,0)
+/* For libavcodec < 57.37.100: input/output was not decoupled */
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,37,100)
     /* Write frame to video */
     int got_data;
     if (avcodec_encode_video2(video->context, &packet, frame, &got_data) < 0) {


### PR DESCRIPTION
From [doc/APIchanges](https://github.com/FFmpeg/FFmpeg/blob/n3.1/doc/APIchanges#L40-L43):

    2016-04-21 - 7fc329e - lavc 57.37.100 - avcodec.h
      Add a new audio/video encoding and decoding API with decoupled input
      and output -- avcodec_send_packet(), avcodec_receive_frame(),
      avcodec_send_frame() and avcodec_receive_packet()

We should be using the older API for anything older than 57.37.100, which does include the version currently in Ubuntu 16.10.