### PR TITLE
GUACAMOLE-194: Free SSH user for VNC+SFTP and RDP+SFTP only once.

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -956,7 +956,6 @@ void* guac_rdp_client_thread(void* data) {
             if (guac_common_ssh_user_import_key(rdp_client->sftp_user,
                         settings->sftp_private_key,
                         settings->sftp_passphrase)) {
-                guac_common_ssh_destroy_user(rdp_client->sftp_user);
                 guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
                         "Private key unreadable.");
                 return NULL;
@@ -983,7 +982,6 @@ void* guac_rdp_client_thread(void* data) {
         /* Fail if SSH connection does not succeed */
         if (rdp_client->sftp_session == NULL) {
             /* Already aborted within guac_common_ssh_create_session() */
-            guac_common_ssh_destroy_user(rdp_client->sftp_user);
             return NULL;
         }
 
@@ -999,8 +997,6 @@ void* guac_rdp_client_thread(void* data) {
 
         /* Abort if SFTP connection fails */
         if (rdp_client->sftp_filesystem == NULL) {
-            guac_common_ssh_destroy_session(rdp_client->sftp_session);
-            guac_common_ssh_destroy_user(rdp_client->sftp_user);
             guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_UNAVAILABLE,
                     "SFTP connection failed.");
             return NULL;

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -243,7 +243,6 @@ void* guac_vnc_client_thread(void* data) {
             if (guac_common_ssh_user_import_key(vnc_client->sftp_user,
                         settings->sftp_private_key,
                         settings->sftp_passphrase)) {
-                guac_common_ssh_destroy_user(vnc_client->sftp_user);
                 guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
                         "Private key unreadable.");
                 return NULL;
@@ -267,7 +266,6 @@ void* guac_vnc_client_thread(void* data) {
         /* Fail if SSH connection does not succeed */
         if (vnc_client->sftp_session == NULL) {
             /* Already aborted within guac_common_ssh_create_session() */
-            guac_common_ssh_destroy_user(vnc_client->sftp_user);
             return NULL;
         }
 
@@ -283,8 +281,6 @@ void* guac_vnc_client_thread(void* data) {
 
         /* Abort if SFTP connection fails */
         if (vnc_client->sftp_filesystem == NULL) {
-            guac_common_ssh_destroy_session(vnc_client->sftp_session);
-            guac_common_ssh_destroy_user(vnc_client->sftp_user);
             guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
                     "SFTP connection failed.");
             return NULL;


### PR DESCRIPTION
Freeing the SFTP user immediately after an init failure results in the user being freed twice: first within the init routine when the failure occurs, and again within the client free handler. Since the client free handler is always invoked, it makes sense to rely on that function alone to handle the cleanup.