### PR TITLE
GUACAMOLE-226: Properly initialize new layers as fully opaque.

### DIFF
--- a/src/common/surface.c
+++ b/src/common/surface.c
@@ -1211,6 +1211,7 @@ guac_common_surface* guac_common_surface_alloc(guac_client* client,
     surface->socket = socket;
     surface->layer = layer;
     surface->parent = GUAC_DEFAULT_LAYER;
+    surface->opacity = 0xFF;
     surface->width = w;
     surface->height = h;
 


### PR DESCRIPTION
All layers are fully opaque by default, and `guac_common_surface` should accurately represent this. Doing otherwise means that newly-joining users of a shared connection will receive the wrong layer opacity, effectively hiding all but the default layer.