### PR TITLE
GUACAMOLE-259: Add TRACE log level.

### DIFF
--- a/src/guacd/conf-args.c
+++ b/src/guacd/conf-args.c
@@ -63,7 +63,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
             /* Validate and parse log level */
             int level = guacd_parse_log_level(optarg);
             if (level == -1) {
-                fprintf(stderr, "Invalid log level. Valid levels are: \"debug\", \"info\", \"warning\", and \"error\".\n");
+                fprintf(stderr, "Invalid log level. Valid levels are: \"trace\", \"debug\", \"info\", \"warning\", and \"error\".\n");
                 return 1;
             }
 

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -78,7 +78,7 @@ static int guacd_conf_callback(const char* section, const char* param, const cha
 
             /* Invalid log level */
             if (level < 0) {
-                guacd_conf_parse_error = "Invalid log level. Valid levels are: \"debug\", \"info\", \"warning\", and \"error\".";
+                guacd_conf_parse_error = "Invalid log level. Valid levels are: \"trace\", \"debug\", \"info\", \"warning\", and \"error\".";
                 return 1;
             }
 

--- a/src/guacd/conf-parse.c
+++ b/src/guacd/conf-parse.c
@@ -527,6 +527,7 @@ int guacd_parse_log_level(const char* name) {
     if (strcmp(name, "error")   == 0) return GUAC_LOG_ERROR;
     if (strcmp(name, "warning") == 0) return GUAC_LOG_WARNING;
     if (strcmp(name, "debug")   == 0) return GUAC_LOG_DEBUG;
+    if (strcmp(name, "trace")   == 0) return GUAC_LOG_TRACE;
 
     /* No such log level */
     return -1;

--- a/src/guacd/log.c
+++ b/src/guacd/log.c
@@ -72,6 +72,12 @@ void vguacd_log(guac_client_log_level level, const char* format,
             priority_name = "DEBUG";
             break;
 
+        /* Trace log level */
+        case GUAC_LOG_TRACE:
+            priority = LOG_DEBUG;
+            priority_name = "TRACE";
+            break;
+
         /* Any unknown/undefined log level */
         default:
             priority = LOG_INFO;

--- a/src/guacd/man/guacd.8
+++ b/src/guacd/man/guacd.8
@@ -66,6 +66,7 @@ Sets the maximum level at which
 .B guacd
 will log messages to syslog and, if running in the foreground, the console.
 Legal values are
+.B trace,
 .B debug,
 .B info,
 .B warning,

--- a/src/guacd/man/guacd.conf.5
+++ b/src/guacd/man/guacd.conf.5
@@ -109,6 +109,7 @@ Sets the maximum level at which
 .B guacd
 will log messages to syslog and, if running in the foreground, the console.
 Legal values are
+.B trace,
 .B debug,
 .B info,
 .B warning,

--- a/src/libguac/guacamole/client-types.h
+++ b/src/libguac/guacamole/client-types.h
@@ -56,8 +56,8 @@ typedef enum guac_client_state {
 
 /**
  * All supported log levels used by the logging subsystem of each Guacamole
- * client. These log levels correspond to a subset of the log levels defined by
- * RFC 5424.
+ * client. With the exception of GUAC_LOG_TRACE, these log levels correspond to
+ * a subset of the log levels defined by RFC 5424.
  */
 typedef enum guac_client_log_level {
 
@@ -78,9 +78,18 @@ typedef enum guac_client_log_level {
 
     /**
      * Informational messages which can be useful for debugging, but are
-     * otherwise not useful to users or administrators.
+     * otherwise not useful to users or administrators. It is expected that
+     * debug level messages, while verbose, will not negatively affect
+     * performance.
      */
-    GUAC_LOG_DEBUG = 7
+    GUAC_LOG_DEBUG = 7,
+
+    /**
+     * Informational messages which can be useful for debugging, like
+     * GUAC_LOG_DEBUG, but which are so low-level that they may affect
+     * performance.
+     */
+    GUAC_LOG_TRACE = 8
 
 } guac_client_log_level;
 


### PR DESCRIPTION
We've avoided adding log levels below DEBUG, as syslog does not support such levels, but as a consequence we are forced to avoid logging which may affect performance, useful though it may be.

This change adds a new TRACE log level to libguac's existing logging facilities, allowing logging of low-level events (like those required by [GUACAMOLE-259](https://issues.apache.org/jira/browse/GUACAMOLE-259)) which would otherwise pollute use of the DEBUG level.