### PR TITLE
GUACAMOLE-282: Correct common surface transfer functions to copy/ignore alpha channel as required.

### DIFF
--- a/src/common/surface.c
+++ b/src/common/surface.c
@@ -724,51 +724,51 @@ static int __guac_common_surface_transfer_int(guac_transfer_function op, uint32_
             break;
 
         case GUAC_TRANSFER_BINARY_NSRC:
-            *dst = ~(*src);
+            *dst = *src ^ 0x00FFFFFF;
             break;
 
         case GUAC_TRANSFER_BINARY_NDEST:
-            *dst = ~(*dst);
+            *dst = *dst ^ 0x00FFFFFF;
             break;
 
         case GUAC_TRANSFER_BINARY_AND:
-            *dst = (*dst) & (*src);
+            *dst = ((*dst) & (0xFF000000 | *src));
             break;
 
         case GUAC_TRANSFER_BINARY_NAND:
-            *dst = ~((*dst) & (*src));
+            *dst = ((*dst) & (0xFF000000 | *src)) ^ 0x00FFFFFF;
             break;
 
         case GUAC_TRANSFER_BINARY_OR:
-            *dst = (*dst) | (*src);
+            *dst = ((*dst) | (0x00FFFFFF & *src));
             break;
 
         case GUAC_TRANSFER_BINARY_NOR:
-            *dst = ~((*dst) | (*src));
+            *dst = ((*dst) | (0x00FFFFFF & *src)) ^ 0x00FFFFFF;
             break;
 
         case GUAC_TRANSFER_BINARY_XOR:
-            *dst = (*dst) ^ (*src);
+            *dst = ((*dst) ^ (0x00FFFFFF & *src));
             break;
 
         case GUAC_TRANSFER_BINARY_XNOR:
-            *dst = ~((*dst) ^ (*src));
+            *dst = ((*dst) ^ (0x00FFFFFF & *src)) ^ 0x00FFFFFF;
             break;
 
         case GUAC_TRANSFER_BINARY_NSRC_AND:
-            *dst = (*dst) & ~(*src);
+            *dst = ((*dst) & (0xFF000000 | (*src ^ 0x00FFFFFF)));
             break;
 
         case GUAC_TRANSFER_BINARY_NSRC_NAND:
-            *dst = ~((*dst) & ~(*src));
+            *dst = ((*dst) & (0xFF000000 | (*src ^ 0x00FFFFFF))) ^ 0x00FFFFFF;
             break;
 
         case GUAC_TRANSFER_BINARY_NSRC_OR:
-            *dst = (*dst) | ~(*src);
+            *dst = ((*dst) | (0x00FFFFFF & (*src ^ 0x00FFFFFF)));
             break;
 
         case GUAC_TRANSFER_BINARY_NSRC_NOR:
-            *dst = ~((*dst) | ~(*src));
+            *dst = ((*dst) | (0x00FFFFFF & (*src ^ 0x00FFFFFF))) ^ 0x00FFFFFF;
             break;
 
     }


### PR DESCRIPTION
From [GUACAMOLE-282](https://issues.apache.org/jira/browse/GUACAMOLE-282):

>
> The common surface implementation used within guacamole-server is incorrect with respect to binary transfer functions as of [GUACAMOLE-188](https://issues.apache.org/jira/browse/GUACAMOLE-188), which added support for the alpha channel to the common surface.
>
> Prior to [GUACAMOLE-188](https://issues.apache.org/jira/browse/GUACAMOLE-188), the common surface supported only the red, green, and blue channels, thus simple binary operations correctly mirrored those of the JavaScript Guacamole client.
>
> After [GUACAMOLE-188](https://issues.apache.org/jira/browse/GUACAMOLE-188), the contents of a surface might have alpha channel values, which are not supposed to be taken into account for all transfer functions. The JavaScript client actually only pays attention to the alpha channel for the following transfer functions:
>
> * `GUAC_TRANSFER_BINARY_SRC` (alpha channel becomes a copy of source)
> * `GUAC_TRANSFER_BINARY_NSRC` (alpha channel becomes a copy of source and is NOT INVERTED)
>
> In all other cases, the alpha channel of the destination is preserved.
>
> The common surface must be modified to duplicate this behavior.

These changes correct the binary operations such that the destination alpha channel is maintained except in the two cases where the source alpha channel must be copied.