### PR TITLE
GUACAMOLE-39: Do not abort VNC/RDP connection if SFTP fails

### DIFF
--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -76,10 +76,11 @@ void guac_common_ssh_uninit();
 /**
  * Connects to the SSH server running at the given hostname and port, and
  * authenticates as the given user. If an error occurs while connecting or
- * authenticating, the Guacamole client will automatically and fatally abort.
- * The user object provided must eventually be explicitly destroyed, but should
- * not be destroyed until this session is destroyed, assuming the session is
- * successfully created.
+ * authenticating, the Guacamole client will only automatically and fatally 
+ * abort if the abort_on_error parameter is non-zero. Errors will always be
+ * logged. The user object provided must eventually be explicitly destroyed,
+ * but should not be destroyed until this session is destroyed, assuming the 
+ * session is successfully created.
  *
  * @param client
  *     The Guacamole client that will be using SSH.
@@ -93,12 +94,17 @@ void guac_common_ssh_uninit();
  * @param user
  *     The user to authenticate as, once connected.
  *
+ * @param abort_on_error
+ *     Whether to automatically and fatally abort if an error occurs whil
+ *     connecting or authenticating.
+ *
  * @return
  *     A new SSH session if the connection and authentication succeed, or NULL
  *     if the connection or authentication were not successful.
  */
 guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
-        const char* hostname, const char* port, guac_common_ssh_user* user);
+        const char* hostname, const char* port, guac_common_ssh_user* user,
+        int abort_on_error);
 
 /**
  * Disconnects and destroys the given SSH session, freeing all associated

--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -95,7 +95,7 @@ void guac_common_ssh_uninit();
  *     The user to authenticate as, once connected.
  *
  * @param abort_on_error
- *     Whether to automatically and fatally abort if an error occurs whil
+ *     Whether to automatically and fatally abort if an error occurs while
  *     connecting or authenticating.
  *
  * @return

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -285,6 +285,38 @@ static void guac_common_ssh_kbd_callback(const char *name, int name_len,
 }
 
 /**
+ *  * A handler for SSH client errors which logs the error and can optionally
+ *   * abort the given guac_client with the given guac_protocol_status.
+ *    *
+ *     * @param client
+ *      *     Guacamole client instance to use when logging or aborting.
+ *       *
+ *        * @param status
+ *         *      Protocol status to return if aborting the connection. This is only
+ *          *      used if abort_on_error is set to true.
+ *           *
+ *            * @param abort_on_error
+ *             *     Whether to abort the connection as well as log the error.
+ *              *     
+ *               * @param format
+ *                *     Format string for log messages. This is also used when aborting 
+ *                 *     the connection.
+ *                  *
+ *                   */
+static void guac_common_ssh_client_error(guac_client* client,
+        guac_protocol_status status, int abort_on_error, const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+
+    if (abort_on_error)
+        vguac_client_abort(client, status, format, args);
+    else
+        vguac_client_log(client, GUAC_LOG_ERROR, format, args);
+
+    va_end(args);
+}
+
+/**
  * Authenticates the user associated with the given session over SSH. All
  * required credentials must already be present within the user object
  * associated with the given session.
@@ -309,7 +341,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 
     /* Validate username provided */
     if (username == NULL) {
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+        guac_client_log(client, GUAC_LOG_ERROR,
                 "SSH authentication requires a username.");
         return 1;
     }
@@ -325,7 +357,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 
         /* Check if public key auth is supported on the server */
         if (strstr(user_authlist, "publickey") == NULL) {
-            guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+            guac_client_log(client, GUAC_LOG_ERROR,
                     "Public key authentication is not supported by "
                     "the SSH server");
             return 1;
@@ -339,7 +371,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
             /* Abort on failure */
             char* error_message;
             libssh2_session_last_error(session, &error_message, NULL, 0);
-            guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+            guac_client_log(client, GUAC_LOG_ERROR,
                     "Public key authentication failed: %s", error_message);
 
             return 1;
@@ -363,8 +395,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
                 /* Abort on failure */
                 char* error_message;
                 libssh2_session_last_error(session, &error_message, NULL, 0);
-                guac_client_abort(client,
-                        GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+                guac_client_log(client, GUAC_LOG_ERROR,
                         "Password authentication failed: %s", error_message);
 
                 return 1;
@@ -385,8 +416,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
                 /* Abort on failure */
                 char* error_message;
                 libssh2_session_last_error(session, &error_message, NULL, 0);
-                guac_client_abort(client,
-                        GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+                guac_client_log(client, GUAC_LOG_ERROR,
                         "Keyboard-interactive authentication failed: %s",
                         error_message);
 
@@ -399,7 +429,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
         }
 
         /* No known authentication types available */
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+        guac_client_log(client, GUAC_LOG_ERROR,
                 "Password and keyboard-interactive authentication are not "
                 "supported by the SSH server");
         return 1;
@@ -407,14 +437,15 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
     }
 
     /* No credentials provided */
-    guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+    guac_client_log(client, GUAC_LOG_ERROR,
             "SSH authentication requires either a private key or a password.");
     return 1;
 
 }
 
 guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
-        const char* hostname, const char* port, guac_common_ssh_user* user) {
+        const char* hostname, const char* port, guac_common_ssh_user* user,
+        int abort_on_error) {
 
     int retval;
 
@@ -434,15 +465,15 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
     /* Get socket */
     fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
-                "Unable to create socket: %s", strerror(errno));
+        guac_common_ssh_client_error(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                abort_on_error, "Unable to create socket: %s", strerror(errno));
         return NULL;
     }
 
     /* Get addresses connection */
     if ((retval = getaddrinfo(hostname, port, &hints, &addresses))) {
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
-                "Error parsing given address or port: %s",
+        guac_common_ssh_client_error(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                abort_on_error, "Error parsing given address or port: %s",
                 gai_strerror(retval));
         close(fd);
         return NULL;
@@ -489,8 +520,8 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
 
     /* If unable to connect to anything, fail */
     if (current_address == NULL) {
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_NOT_FOUND,
-                "Unable to connect to any addresses.");
+        guac_common_ssh_client_error(client, GUAC_PROTOCOL_STATUS_UPSTREAM_NOT_FOUND,
+                abort_on_error, "Unable to connect to any addresses.");
         close(fd);
         return NULL;
     }
@@ -503,8 +534,8 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
     LIBSSH2_SESSION* session = libssh2_session_init_ex(NULL, NULL,
             NULL, common_session);
     if (session == NULL) {
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
-                "Session allocation failed.");
+        guac_common_ssh_client_error(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                abort_on_error, "Session allocation failed.");
         free(common_session);
         close(fd);
         return NULL;
@@ -512,8 +543,8 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
 
     /* Perform handshake */
     if (libssh2_session_handshake(session, fd)) {
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
-                "SSH handshake failed.");
+        guac_common_ssh_client_error(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR,
+                abort_on_error, "SSH handshake failed.");
         free(common_session);
         close(fd);
         return NULL;
@@ -527,6 +558,8 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
 
     /* Attempt authentication */
     if (guac_common_ssh_authenticate(common_session)) {
+        guac_common_ssh_client_error(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+                abort_on_error, "SSH authentication failed.");
         free(common_session);
         close(fd);
         return NULL;

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -285,24 +285,24 @@ static void guac_common_ssh_kbd_callback(const char *name, int name_len,
 }
 
 /**
- *  * A handler for SSH client errors which logs the error and can optionally
- *   * abort the given guac_client with the given guac_protocol_status.
- *    *
- *     * @param client
- *      *     Guacamole client instance to use when logging or aborting.
- *       *
- *        * @param status
- *         *      Protocol status to return if aborting the connection. This is only
- *          *      used if abort_on_error is set to true.
- *           *
- *            * @param abort_on_error
- *             *     Whether to abort the connection as well as log the error.
- *              *     
- *               * @param format
- *                *     Format string for log messages. This is also used when aborting 
- *                 *     the connection.
- *                  *
- *                   */
+ * A handler for SSH client errors which logs the error and can optionally
+ * abort the given guac_client with the given guac_protocol_status.
+ *
+ * @param client
+ *     Guacamole client instance to use when logging or aborting.
+ *
+ * @param status
+ *      Protocol status to return if aborting the connection. This is only
+ *      used if abort_on_error is set to true.
+ *
+ * @param abort_on_error
+ *     Whether to abort the connection as well as log the error.
+ *    
+ * @param format
+ *     Format string for log messages. This is also used when aborting 
+ *     the connection.
+ *
+ **/
 static void guac_common_ssh_client_error(guac_client* client,
         guac_protocol_status status, int abort_on_error, const char* format, ...) {
     va_list args;

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -218,7 +218,7 @@ void* ssh_client_thread(void* data) {
 
     /* Open SSH session */
     ssh_client->session = guac_common_ssh_create_session(client,
-            settings->hostname, settings->port, ssh_client->user);
+            settings->hostname, settings->port, ssh_client->user, 1);
     if (ssh_client->session == NULL) {
         /* Already aborted within guac_common_ssh_create_session() */
         return NULL;
@@ -258,7 +258,7 @@ void* ssh_client_thread(void* data) {
         guac_client_log(client, GUAC_LOG_DEBUG, "Reconnecting for SFTP...");
         ssh_client->sftp_session =
             guac_common_ssh_create_session(client, settings->hostname,
-                    settings->port, ssh_client->user);
+                    settings->port, ssh_client->user, 1);
         if (ssh_client->sftp_session == NULL) {
             /* Already aborted within guac_common_ssh_create_session() */
             return NULL;


### PR DESCRIPTION
Re-implementation in the current code base of the changes in the previous pull request for GUACAMOLE-39.  For VNC/RDP connections, this PR now logs the failure rather than aborting the connection.  This allows the primary connection to succeed regardless of the secondary SFTP connection.