### PR TITLE
GUACAMOLE-326: Explicitly deny attempted reads/writes to Windows named data streams.

### DIFF
--- a/src/protocols/rdp/rdp_fs.c
+++ b/src/protocols/rdp/rdp_fs.c
@@ -654,6 +654,10 @@ int guac_rdp_fs_normalize_path(const char* path, char* abs_path) {
 
         } /* end if separator */
 
+        /* We do not currently support named streams */
+        else if (c == ':')
+            return 1;
+
     } /* end for each character */
 
     /* If no components, the path is simply root */


### PR DESCRIPTION
From [GUACAMOLE-326](https://issues.apache.org/jira/browse/GUACAMOLE-326):

> When a file has been downloaded over the internet via Windows 10, and that file is later transferred over Guacamole using the magic "Download" folder, multiple files end up being transferred: "filename.ext" and "filename.ext:ZoneIdentifier".
>
> This is due to the way Windows 10 tags files downloaded over the internet with secondary "streams", such that it can warn users of the risks prior to executing those files:
>
> http://stackoverflow.com/questions/4496697/what-is-zone-identifier
>
> As Guacamole does not actually use such files, and the underlying filesystem does not support them, they should be appropriately ignored/rejected rather than downloaded.