### PR TITLE
GUACAMOLE-303: Allow root directory of SFTP filesystem to be configured.

### DIFF
--- a/src/common-ssh/common-ssh/sftp.h
+++ b/src/common-ssh/common-ssh/sftp.h
@@ -34,6 +34,11 @@
 #define GUAC_COMMON_SSH_SFTP_MAX_PATH 2048
 
 /**
+ * Maximum number of path components per path.
+ */
+#define GUAC_COMMON_SSH_SFTP_MAX_DEPTH 1024
+
+/**
  * Representation of an SFTP-driven filesystem object. Unlike guac_object, this
  * structure is not tied to any particular user.
  */
@@ -53,6 +58,11 @@ typedef struct guac_common_ssh_sftp_filesystem {
      * SFTP session, used for file transfers.
      */
     LIBSSH2_SFTP* sftp_session;
+
+    /**
+     * The path to the directory to expose to the user as a filesystem object.
+     */
+    char root_path[GUAC_COMMON_SSH_SFTP_MAX_PATH];
 
     /**
      * The path files will be sent to, if uploaded directly via a "file"
@@ -103,15 +113,22 @@ typedef struct guac_common_ssh_sftp_ls_state {
  *     The session to use to provide SFTP. This session will automatically be
  *     destroyed when this filesystem is destroyed.
  *
+ * @param root_path
+ *     The path accessible via SFTP to consider the root path of the filesystem
+ *     exposed to the user. Only the contents of this path will be available
+ *     via the filesystem object.
+ *
  * @param name
  *     The name to send as the name of the filesystem whenever it is exposed
- *     to a user.
+ *     to a user, or NULL to automatically generate a name from the provided
+ *     root_path.
  *
  * @return
  *     A new SFTP filesystem object, not yet exposed to users.
  */
 guac_common_ssh_sftp_filesystem* guac_common_ssh_create_sftp_filesystem(
-        guac_common_ssh_session* session, const char* name);
+        guac_common_ssh_session* session, const char* root_path,
+        const char* name);
 
 /**
  * Destroys the given filesystem object, disconnecting from SFTP and freeing

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -988,7 +988,7 @@ void* guac_rdp_client_thread(void* data) {
         /* Load and expose filesystem */
         rdp_client->sftp_filesystem =
             guac_common_ssh_create_sftp_filesystem(
-                    rdp_client->sftp_session, "/");
+                    rdp_client->sftp_session, "/", NULL);
 
         /* Expose filesystem to connection owner */
         guac_client_for_owner(client,

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -987,8 +987,8 @@ void* guac_rdp_client_thread(void* data) {
 
         /* Load and expose filesystem */
         rdp_client->sftp_filesystem =
-            guac_common_ssh_create_sftp_filesystem(
-                    rdp_client->sftp_session, "/", NULL);
+            guac_common_ssh_create_sftp_filesystem(rdp_client->sftp_session,
+                    settings->sftp_root_directory, NULL);
 
         /* Expose filesystem to connection owner */
         guac_client_for_owner(client,

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -84,6 +84,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "sftp-private-key",
     "sftp-passphrase",
     "sftp-directory",
+    "sftp-root-directory",
     "sftp-server-alive-interval",
 #endif
 
@@ -366,6 +367,12 @@ enum RDP_ARGS_IDX {
      * the destination directory is otherwise ambiguous).
      */
     IDX_SFTP_DIRECTORY,
+
+    /**
+     * The path of the directory within the SSH server to expose as a
+     * filesystem guac_object. If omitted, "/" will be used by default.
+     */
+    IDX_SFTP_ROOT_DIRECTORY,
 
     /**
      * The interval at which SSH keepalive messages are sent to the server for
@@ -784,6 +791,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
         guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_SFTP_DIRECTORY, NULL);
 
+    /* SFTP root directory */
+    settings->sftp_root_directory =
+        guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_SFTP_ROOT_DIRECTORY, "/");
+
     /* Default keepalive value */
     settings->sftp_server_alive_interval =
         guac_user_parse_args_int(user, GUAC_RDP_CLIENT_ARGS, argv,
@@ -909,6 +921,7 @@ void guac_rdp_settings_free(guac_rdp_settings* settings) {
 #ifdef ENABLE_COMMON_SSH
     /* Free SFTP settings */
     free(settings->sftp_directory);
+    free(settings->sftp_root_directory);
     free(settings->sftp_hostname);
     free(settings->sftp_passphrase);
     free(settings->sftp_password);

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -361,6 +361,12 @@ typedef struct guac_rdp_settings {
     char* sftp_directory;
 
     /**
+     * The path of the directory within the SSH server to expose as a
+     * filesystem guac_object.
+     */
+    char* sftp_root_directory;
+
+    /**
      * The interval at which SSH keepalive messages are sent to the server for
      * SFTP connections.  The default is 0 (disabling keepalives), and a value
      * of 1 is automatically increased to 2 by libssh2 to avoid busy loop corner

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -37,6 +37,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "font-name",
     "font-size",
     "enable-sftp",
+    "sftp-root-directory",
     "private-key",
     "passphrase",
 #ifdef ENABLE_SSH_AGENT
@@ -91,6 +92,12 @@ enum SSH_ARGS_IDX {
      * Whether SFTP should be enabled.
      */
     IDX_ENABLE_SFTP,
+
+    /**
+     * The path of the directory within the SSH server to expose as a
+     * filesystem guac_object. If omitted, "/" will be used by default.
+     */
+    IDX_SFTP_ROOT_DIRECTORY,
 
     /**
      * The private key to use for authentication, if any.
@@ -236,6 +243,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
         guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_ENABLE_SFTP, false);
 
+    /* SFTP root directory */
+    settings->sftp_root_directory =
+        guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_SFTP_ROOT_DIRECTORY, "/");
+
 #ifdef ENABLE_SSH_AGENT
     settings->enable_agent =
         guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
@@ -315,6 +327,9 @@ void guac_ssh_settings_free(guac_ssh_settings* settings) {
 
     /* Free requested command */
     free(settings->command);
+
+    /* Free SFTP settings */
+    free(settings->sftp_root_directory);
 
     /* Free typescript settings */
     free(settings->typescript_name);

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -145,6 +145,12 @@ typedef struct guac_ssh_settings {
      */
     bool enable_sftp;
 
+    /**
+     * The path of the directory within the SSH server to expose as a
+     * filesystem guac_object.
+     */
+    char* sftp_root_directory;
+
 #ifdef ENABLE_SSH_AGENT
     /**
      * Whether the SSH agent is enabled.

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -266,7 +266,8 @@ void* ssh_client_thread(void* data) {
 
         /* Request SFTP */
         ssh_client->sftp_filesystem = guac_common_ssh_create_sftp_filesystem(
-                    ssh_client->sftp_session, "/", NULL);
+                    ssh_client->sftp_session, settings->sftp_root_directory,
+                    NULL);
 
         /* Expose filesystem to connection owner */
         guac_client_for_owner(client,

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -266,7 +266,7 @@ void* ssh_client_thread(void* data) {
 
         /* Request SFTP */
         ssh_client->sftp_filesystem = guac_common_ssh_create_sftp_filesystem(
-                    ssh_client->sftp_session, "/");
+                    ssh_client->sftp_session, "/", NULL);
 
         /* Expose filesystem to connection owner */
         guac_client_for_owner(client,

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -66,6 +66,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "sftp-private-key",
     "sftp-passphrase",
     "sftp-directory",
+    "sftp-root-directory",
     "sftp-server-alive-interval",
 #endif
 
@@ -228,6 +229,12 @@ enum VNC_ARGS_IDX {
      * the destination directory is otherwise ambiguous).
      */
     IDX_SFTP_DIRECTORY,
+
+    /**
+     * The path of the directory within the SSH server to expose as a
+     * filesystem guac_object. If omitted, "/" will be used by default.
+     */
+    IDX_SFTP_ROOT_DIRECTORY,
 
     /**
      * The interval at which SSH keepalive messages are sent to the server for
@@ -405,6 +412,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
         guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_SFTP_DIRECTORY, NULL);
 
+    /* SFTP root directory */
+    settings->sftp_root_directory =
+        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_SFTP_ROOT_DIRECTORY, "/");
+
     /* Default keepalive value */
     settings->sftp_server_alive_interval =
         guac_user_parse_args_int(user, GUAC_VNC_CLIENT_ARGS, argv,
@@ -447,6 +459,7 @@ void guac_vnc_settings_free(guac_vnc_settings* settings) {
 #ifdef ENABLE_COMMON_SSH
     /* Free SFTP settings */
     free(settings->sftp_directory);
+    free(settings->sftp_root_directory);
     free(settings->sftp_hostname);
     free(settings->sftp_passphrase);
     free(settings->sftp_password);

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -175,6 +175,12 @@ typedef struct guac_vnc_settings {
     char* sftp_directory;
 
     /**
+     * The path of the directory within the SSH server to expose as a
+     * filesystem guac_object.
+     */
+    char* sftp_root_directory;
+
+    /**
      * The interval at which SSH keepalive messages are sent to the server for
      * SFTP connections.  The default is 0 (disabling keepalives), and a value
      * of 1 is automatically increased to 2 by libssh2 to avoid busy loop corner

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -272,7 +272,7 @@ void* guac_vnc_client_thread(void* data) {
         /* Load filesystem */
         vnc_client->sftp_filesystem =
             guac_common_ssh_create_sftp_filesystem(
-                    vnc_client->sftp_session, "/");
+                    vnc_client->sftp_session, "/", NULL);
 
         /* Expose filesystem to connection owner */
         guac_client_for_owner(client,

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -271,8 +271,8 @@ void* guac_vnc_client_thread(void* data) {
 
         /* Load filesystem */
         vnc_client->sftp_filesystem =
-            guac_common_ssh_create_sftp_filesystem(
-                    vnc_client->sftp_session, "/", NULL);
+            guac_common_ssh_create_sftp_filesystem(vnc_client->sftp_session,
+                    settings->sftp_root_directory, NULL);
 
         /* Expose filesystem to connection owner */
         guac_client_for_owner(client,


### PR DESCRIPTION
This change adds a new "sftp-root-directory" parameter to VNC, RDP, and SSH which defines the root directory exposed via Guacamole's file browser. Some care is taken to ensure that requests outside this root directory cannot be made via the file browse, in that both the root directory and the requested filename are normalized prior to being concatenated.