### PR TITLE
GUACAMOLE-296: Fix linking issue that causes audio issues with FreeRDP 1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -506,6 +506,7 @@ fi
 
 have_freerdp=disabled
 RDP_LIBS=
+WINPR_LIBS=
 AC_ARG_WITH([rdp],
             [AS_HELP_STRING([--with-rdp],
                             [support RDP @<:@default=check@:>@])],
@@ -695,7 +696,7 @@ fi
 # Check for stream support via WinPR
 if test "x${have_freerdp}" = "xyes"
 then
-    AC_CHECK_HEADER(winpr/stream.h,[RDP_LIBS="$RDP_LIBS -lwinpr-utils"],
+    AC_CHECK_HEADER(winpr/stream.h,[WINPR_LIBS="$WINPR_LIBS -lwinpr-utils"],
                     [have_winpr=no,
                      AC_CHECK_DECL([stream_write_uint8],,
                                   [AC_MSG_WARN([
@@ -1015,6 +1016,7 @@ AM_CONDITIONAL([ENABLE_WINPR], [test "x${have_winpr}"   = "xyes"])
 AM_CONDITIONAL([ENABLE_RDP],   [test "x${have_freerdp}" = "xyes"])
 
 AC_SUBST(RDP_LIBS)
+AC_SUBST(WINPR_LIBS)
 
 #
 # libssh2

--- a/configure.ac
+++ b/configure.ac
@@ -695,7 +695,7 @@ fi
 # Check for stream support via WinPR
 if test "x${have_freerdp}" = "xyes"
 then
-    AC_CHECK_HEADER(winpr/stream.h,,
+    AC_CHECK_HEADER(winpr/stream.h,[RDP_LIBS="$RDP_LIBS -lwinpr-utils"],
                     [have_winpr=no,
                      AC_CHECK_DECL([stream_write_uint8],,
                                   [AC_MSG_WARN([

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -185,7 +185,8 @@ guacai_cflags               =  \
 guacai_ldflags =                   \
     -module -avoid-version -shared \
     @PTHREAD_LIBS@                 \
-    @RDP_LIBS@
+    @RDP_LIBS@                     \
+    @WINPR_LIBS@
 
 guacai_libadd =     \
     @COMMON_LTLIB@  \


### PR DESCRIPTION
This is a very minor tweak to the configure.ac file that adds the winpr-utils library to the list of libraries linked when the winpr/stream.h file is found.  This works correctly for FreeRDP 1.0 (winpr/stream.h is not present) and FreeRDP 1.1 (winpr/stream.h is present), but probably not FreeRDP 2.0, as winpr libraries got significantly collapsed there.  But, I think there may be other issues with FreeRDP 2.0 and the Guacamole server.