### PR TITLE
GUACAMOLE-344: switching to upstream libvncserver because it properly enables VeNCrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ ENV \
         libtool                       \
         libtelnet-devel               \
         libvorbis-devel               \
-        libvncserver-devel            \
         libwebp-devel                 \
         make                          \
         pango-devel                   \
@@ -77,6 +76,12 @@ COPY . "$BUILD_DIR"
 
 # Build guacamole-server from local source
 RUN yum -y install $BUILD_DEPENDENCIES         && \
+    curl -L https://codeload.github.com/LibVNC/libvncserver/tar.gz/LibVNCServer-0.9.11 | tar -zx && \
+    cd libvncserver-LibVNCServer-0.9.11 && \
+    ./autogen.sh && \
+    make install && \
+    cd .. && \
+    rm -fr libvncserver-LibVNCServer-0.9.11 && \
     /opt/guacd/bin/build-guacd.sh "$BUILD_DIR" && \
     rm -Rf "$BUILD_DIR"                        && \
     yum -y autoremove $BUILD_DEPENDENCIES      && \


### PR DESCRIPTION
This is a PR resolving https://issues.apache.org/jira/browse/GUACAMOLE-344