### PR TITLE
GUACAMOLE-383: resolve issues identified by cppcheck

### DIFF
--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -203,6 +203,7 @@ guacd_config* guacd_conf_load() {
     /* Notify of errors preventing reading */
     else if (errno != ENOENT) {
         fprintf(stderr, "Unable to open \"" GUACD_CONF_FILE "\": %s\n", strerror(errno));
+        free(conf);
         return NULL;
     }
 

--- a/src/protocols/rdp/rdp_cliprdr.c
+++ b/src/protocols/rdp/rdp_cliprdr.c
@@ -202,6 +202,7 @@ void guac_rdp_process_cb_data_request(guac_client* client,
         default:
             guac_client_log(client, GUAC_LOG_ERROR, 
                     "Server requested unsupported clipboard data type");
+            free(output);
             return;
 
     }

--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -280,6 +280,7 @@ guac_terminal_display* guac_terminal_display_alloc(guac_client* client,
     font = pango_font_map_load_font(font_map, context, display->font_desc);
     if (font == NULL) {
         guac_client_abort(display->client, GUAC_PROTOCOL_STATUS_SERVER_ERROR, "Unable to get font \"%s\"", font_name);
+        free(display);
         return NULL;
     }
 
@@ -287,6 +288,7 @@ guac_terminal_display* guac_terminal_display_alloc(guac_client* client,
     if (metrics == NULL) {
         guac_client_abort(display->client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
                 "Unable to get font metrics for font \"%s\"", font_name);
+        free(display);
         return NULL;
     }
 


### PR DESCRIPTION
[src/guacd/conf-file.c:206]: (error) Memory leak: conf
[src/protocols/rdp/rdp_cliprdr.c:205]: (error) Memory leak: output
[src/terminal/display.c:283]: (error) Memory leak: display
[src/terminal/display.c:290]: (error) Memory leak: display