### PR TITLE
GUACAMOLE-400: Fix guacd crash when ssh key fails

### DIFF
--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -63,7 +63,8 @@
  *     terminal to use when prompting the user.
  *
  * @return
- *     A new user object containing the user's username and other credentials.
+ *     A new user object containing the user's username and other credentials,
+ *     or NULL if fails to import key.
  */
 static guac_common_ssh_user* guac_ssh_get_user(guac_client* client) {
 
@@ -215,6 +216,10 @@ void* ssh_client_thread(void* data) {
 
     /* Get user and credentials */
     ssh_client->user = guac_ssh_get_user(client);
+    if (ssh_client->user == NULL) {
+        /* Already aborted within guac_ssh_get_user() */
+        return NULL;
+    }
 
     /* Open SSH session */
     ssh_client->session = guac_common_ssh_create_session(client,


### PR DESCRIPTION
Root Cause:
In the ssh library of guacd, function ssh_client_thread(), when guac_ssh_get_user() fails to load private key for ssh authentication, it will return NULL. In this case, the subsequent call to guac_common_ssh_create_session() with parameter 'user=0x0' will cause guacd crash in function guac_common_ssh_authenticate() by accessing 'user->username'.

Solution:
In guac_common_ssh_create_session(), validate parameter 'user'. If it is NULL, abort the ssh session.
Reviewed the logic for other parameters of the function, they look okay and no need to be validated at this point.

Test:
- configured a ssh app with an encrypted private key and a wrong passphrase.
- ran the ssh app from web portal and observed guacd crash.
- applied the fix and reran the ssh app. Observed no crash.