### PR TITLE
GUACAMOLE-411: Fixed using uninitialized values in guacd_send_fd

### DIFF
--- a/src/guacd/move-fd.c
+++ b/src/guacd/move-fd.c
@@ -44,7 +44,7 @@ int guacd_send_fd(int sock, int fd) {
     message.msg_iovlen = 1;
 
     /* Assign ancillary data buffer */
-    char buffer[CMSG_SPACE(sizeof(fd))];
+    char buffer[CMSG_SPACE(sizeof(fd))] = {0};
     message.msg_control = buffer;
     message.msg_controllen = sizeof(buffer);
 


### PR DESCRIPTION
Fixed valgrind's complaints when sending fds.
```
==8081== Thread 2:
==8081== Syscall param sendmsg(msg.msg_control) points to uninitialised byte(s)
==8081==    at 0x505EA6D: ??? (syscall-template.S:84)
==8081==    by 0x403F5C: guacd_send_fd (move-fd.c:61)
==8081==    by 0x40390A: guacd_add_user (connection.c:196)
==8081==    by 0x40390A: guacd_route_connection (connection.c:311)
==8081==    by 0x40390A: guacd_connection_thread (connection.c:393)
==8081==    by 0x50556B9: start_thread (pthread_create.c:333)
==8081==    by 0x5A1F3DC: clone (clone.S:109)
==8081==  Address 0xa558d54 is on thread 2's stack
==8081==  in frame #1, created by guacd_send_fd (move-fd.c:34)
==8081==  Uninitialised value was created by a stack allocation
==8081==    at 0x403ED0: guacd_send_fd (move-fd.c:34)
==8081== 
```