### PR TITLE
GUACAMOLE-402: fix out-of-tree build

### DIFF
--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -115,7 +115,7 @@ libguacinc_HEADERS += guacamole/socket-wsa.h
 endif
 
 libguac_la_CFLAGS = \
-    -Werror -Wall -pedantic -Iguacamole
+    -Werror -Wall -pedantic -I$(srcdir)/guacamole
 
 libguac_la_LDFLAGS =     \
     -version-info 14:0:2 \

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -247,18 +247,18 @@ CLEANFILES = _generated_keymaps.c
 BUILT_SOURCES = _generated_keymaps.c
 
 rdp_keymaps =                   \
-    keymaps/base.keymap         \
-    keymaps/failsafe.keymap     \
-    keymaps/de_de_qwertz.keymap \
-    keymaps/en_us_qwerty.keymap \
-    keymaps/fr_fr_azerty.keymap \
-    keymaps/fr_ch_qwertz.keymap \
-    keymaps/it_it_qwerty.keymap \
-    keymaps/ja_jp_qwerty.keymap \
-    keymaps/sv_se_qwerty.keymap
+    $(srcdir)/keymaps/base.keymap         \
+    $(srcdir)/keymaps/failsafe.keymap     \
+    $(srcdir)/keymaps/de_de_qwertz.keymap \
+    $(srcdir)/keymaps/en_us_qwerty.keymap \
+    $(srcdir)/keymaps/fr_fr_azerty.keymap \
+    $(srcdir)/keymaps/fr_ch_qwertz.keymap \
+    $(srcdir)/keymaps/it_it_qwerty.keymap \
+    $(srcdir)/keymaps/ja_jp_qwerty.keymap \
+    $(srcdir)/keymaps/sv_se_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps)
-	keymaps/generate.pl $(rdp_keymaps)
+	$(srcdir)/keymaps/generate.pl $(rdp_keymaps)
 
 EXTRA_DIST =            \
     $(rdp_keymaps)      \


### PR DESCRIPTION
Use $(srcdir) in places were it's needed, so that an out-of-tree build works.