### PR TITLE
GUACAMOLE-296: Revert manual addition of winpr-utils library.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -506,7 +506,6 @@ fi
 
 have_freerdp=disabled
 RDP_LIBS=
-WINPR_LIBS=
 AC_ARG_WITH([rdp],
             [AS_HELP_STRING([--with-rdp],
                             [support RDP @<:@default=check@:>@])],
@@ -696,7 +695,7 @@ fi
 # Check for stream support via WinPR
 if test "x${have_freerdp}" = "xyes"
 then
-    AC_CHECK_HEADER(winpr/stream.h,[WINPR_LIBS="$WINPR_LIBS -lwinpr-utils"],
+    AC_CHECK_HEADER(winpr/stream.h,,
                     [have_winpr=no,
                      AC_CHECK_DECL([stream_write_uint8],,
                                   [AC_MSG_WARN([
@@ -1016,7 +1015,6 @@ AM_CONDITIONAL([ENABLE_WINPR], [test "x${have_winpr}"   = "xyes"])
 AM_CONDITIONAL([ENABLE_RDP],   [test "x${have_freerdp}" = "xyes"])
 
 AC_SUBST(RDP_LIBS)
-AC_SUBST(WINPR_LIBS)
 
 #
 # libssh2

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -185,8 +185,7 @@ guacai_cflags               =  \
 guacai_ldflags =                   \
     -module -avoid-version -shared \
     @PTHREAD_LIBS@                 \
-    @RDP_LIBS@                     \
-    @WINPR_LIBS@
+    @RDP_LIBS@
 
 guacai_libadd =     \
     @COMMON_LTLIB@  \


### PR DESCRIPTION
Reverts manual changes made to the RDP protocol Makefile.am to add in winpr-utils, which now seems to be linking automatically.